### PR TITLE
made whois more compatible

### DIFF
--- a/lib/plugins/whois.js
+++ b/lib/plugins/whois.js
@@ -143,7 +143,7 @@ module.exports = function () {
                 target = params[1];
                 user = irc.getUser(target, network);
 
-                if (msg.trailing === 'is logged in as') {
+                if (msg.trailing.toLowerCase() === 'is logged in as') {
                     map[target] = map[target] || {};
                     user.account = params[2];
                     map[target].account = params[2];
@@ -153,8 +153,7 @@ module.exports = function () {
                 params = msg.params.split(' ');
                 target = params[1];
                 user = irc.getUser(target, network);
-
-                if (msg.trailing === 'is a registered nick') {
+                if (msg.trailing.toLowerCase() === 'is a registered nick' || msg.trailing.toLowerCase() === 'is identified for this nick') {
                     map[target] = map[target] || {};
                     user.registered = true;
                     map[target].registered = true;
@@ -165,7 +164,7 @@ module.exports = function () {
                 target = params[1];
                 user = irc.getUser(target, network);
 
-                if (msg.trailing === 'is using a secure connection') {
+                if (msg.trailing.toLowerCase() === 'is using a secure connection') {
                     map[target] = map[target] || {};
                     user.secure = true;
                     map[target].secure = true;


### PR DESCRIPTION
case may differ from network to network, that's why I added .toLowerCase()
also the default message for registered accounts on most of the networks is 'is identified for this nick' so I added it too