### PR TITLE
fixed names callback for upper case channel names

### DIFF
--- a/lib/plugins/names.js
+++ b/lib/plugins/names.js
@@ -31,7 +31,7 @@ module.exports = function () {
             }
 
             if (typeof channel !== "string") {
-                channel = utils.targetString(channel);
+                channel = utils.targetString(channel).toLowerCase();
 
                 // extract network from channel/user object
                 if (!network) {
@@ -60,14 +60,14 @@ module.exports = function () {
             var network = msg.network;
             var channelName, channel, cb;
             if (msg.command === 'RPL_NAMREPLY') {
-                channelName = msg.params.split(' ')[2];
+                channelName = msg.params.split(' ')[2].toLowerCase();
                 nameReply[channelName] = nameReply[channelName] || {};
                 msg.trailing.split(' ').forEach(function (name) {
                     var m = name.match(/^((!|~|&|@|%|\+)*)(.*)$/);
                     nameReply[channelName][m[3]] = m[1].split('');
                 });
             } else if (msg.command === 'RPL_ENDOFNAMES') {
-                channelName = msg.params.split(' ')[1];
+                channelName = msg.params.split(' ')[1].toLowerCase();
                 channel = irc.getChannel(channelName, network);
                 cb = irc.nameCallbacks[channelName];
                 channel.names = nameReply[channelName];


### PR DESCRIPTION
The .names() call wasn't working for channel names which contains upper case letters. This commit fixes this problem.

You really should've tested coffea a bit more tbh ^^