### PR TITLE
set registered true if account name is present in whois

### DIFF
--- a/lib/plugins/whois.js
+++ b/lib/plugins/whois.js
@@ -143,7 +143,7 @@ module.exports = function () {
                 target = params[1];
                 user = irc.getUser(target, network);
 
-                if (msg.trailing.toLowerCase() === 'is logged in as') {
+                if (msg.trailing.toLowerCase() === 'is logged in as' || msg.trailing.toLowerCase() === 'is authed as') {
                     map[target] = map[target] || {};
                     user.account = params[2];
                     map[target].account = params[2];

--- a/lib/plugins/whois.js
+++ b/lib/plugins/whois.js
@@ -147,6 +147,8 @@ module.exports = function () {
                     map[target] = map[target] || {};
                     user.account = params[2];
                     map[target].account = params[2];
+                    user.registered = true;
+                    map[target].registered = true;
                 }
                 break;
             case '307':


### PR DESCRIPTION
This is useful since many networks nowadays don't show a message like "is identified for this nick" in addition to the account message.